### PR TITLE
Add normalize space to topic element on student evalution page

### DIFF
--- a/automated_initial_assessment.ipynb
+++ b/automated_initial_assessment.ipynb
@@ -228,7 +228,7 @@
     "\n",
     "            # Fill all the score and comment\n",
     "            for topic in topic_list:\n",
-    "                child_elem = driver.find_element(By.XPATH, '//p[text()=\"{}\"]'.format(topic))\n",
+    "                child_elem = driver.find_element(By.XPATH, '//p[normalize-space(text())=\"{}\"]'.format(topic))\n",
     "                parent_elem = child_elem.find_element(By.XPATH, \"..\")\n",
     "                textarea_elem = parent_elem.find_element(By.TAG_NAME, \"textarea\")\n",
     "\n",


### PR DESCRIPTION
Added normalize-space() function in order to normalizes tabs and whitespaces on the element of the student evaluation page. Might be useful for CC mentors.